### PR TITLE
Refactor main navigation

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,5 @@
 import './globals.css';
 import { GeistSans } from 'geist/font/sans';
-import { cookies } from 'next/headers';
-import { createClient } from '@/lib/supabase/server';
 import { cn } from '@/lib/utils';
 import ThemeProvider from '@/components/ThemeProvider';
 import MainNavigation from '@/components/MainNavigation';
@@ -18,16 +16,11 @@ export const metadata = {
   keywords: ['Next.js', 'React', 'TypeScript', 'JavaScript', 'Supabase', 'Tailwind CSS'],
   authors: { name: 'Krzysztof Borecki', url: 'https://github.com/K3orecki' },
 };
-
 export default async function RootLayout({
   children,
 }: {
   children: ReactNode
 }) {
-  const cookieStore = cookies();
-  const supabase = createClient(cookieStore);
-  const { data: { user } } = await supabase.auth.getUser();
-
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={cn(
@@ -40,7 +33,7 @@ export default async function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <MainNavigation userEmail={user?.email}/>
+          <MainNavigation/>
           <main className="w-full flex-1 flex flex-col items-center animate-in relative">
             {children}
           </main>

--- a/components/MainNavigation.tsx
+++ b/components/MainNavigation.tsx
@@ -1,73 +1,21 @@
-'use client';
+'use server';
 
-import { usePathname } from 'next/navigation';
-import { signOut } from '@/app/actions';
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
+import MainNavigationMenu from '@/components/MainNavigationMenu';
 import Logo from '@/components/Logo';
-import ThemeToggleButton from '@/components/ThemeToggleButton';
-import { Home } from 'lucide-react';
 
-export default function MainNavigation({
-  userEmail
-}: {
-  userEmail: string | undefined
-}) {
-  const pathname = usePathname();
+export default async function MainNavigation() {
+  const cookieStore = cookies();
+  const supabase = createClient(cookieStore);
+  const { data: { user } } = await supabase.auth.getUser();
 
   return (
     <header className="w-full sticky top-0 z-40">
       <nav className="w-full border-b border-b-foreground/10 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 text-sm">
         <div className="container h-navbar flex justify-between items-center">
           <Logo />
-          <ul className="flex items-center gap-1">
-            <li>
-              <Link
-                href="/"
-                className={cn(
-                  buttonVariants({ variant: 'ghost' }),
-                  'px-2 md:px-4',
-                  'hover:bg-transparent hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0',
-                  pathname === '/' ? 'text-foreground' : 'text-foreground/60'
-                )}
-              >
-                <p className="invisible w-0 sm:visible sm:w-auto">Home</p>
-                <Home className="sm:invisible sm:w-0" />
-              </Link>
-            </li>
-            <li>
-              {userEmail ? (
-                <div className="flex items-center gap-4 font-medium text-foreground/60">
-                  Hi, {userEmail}!
-                  <form action={signOut}>
-                    <button className={cn(
-                      buttonVariants({ variant: 'ghost' }),
-                      'px-2 md:px-4',
-                      'hover:bg-transparent hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0',
-                    )}>
-                      Log Out
-                    </button>
-                  </form>
-                </div>
-              ) : (
-                <Link
-                  href="/login"
-                  className={cn(
-                    buttonVariants({ variant: 'ghost' }),
-                    'px-2 md:px-4',
-                    'hover:bg-transparent hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0',
-                    pathname === '/login' ? 'text-foreground' : 'text-foreground/60',
-                  )}
-                >
-                  Log In
-                </Link>
-              )}
-            </li>
-            <li>
-              <ThemeToggleButton />
-            </li>
-          </ul>
+          <MainNavigationMenu userEmail={user?.email}/>
         </div>
       </nav>
     </header>

--- a/components/MainNavigationMenu.tsx
+++ b/components/MainNavigationMenu.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { signOut } from '@/app/actions';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+import ThemeToggleButton from '@/components/ThemeToggleButton';
+import { Home } from 'lucide-react';
+
+export default function MainNavigationMenu({
+  userEmail
+}: {
+  userEmail: string | undefined
+}) {
+  const pathname = usePathname();
+
+  return (
+    <ul className="flex items-center gap-1">
+      <li>
+        <Link
+          href="/"
+          className={cn(
+            buttonVariants({ variant: 'ghost' }),
+            'px-2 md:px-4',
+            'hover:bg-transparent hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0',
+            pathname === '/' ? 'text-foreground' : 'text-foreground/60'
+          )}
+        >
+          <p className="invisible w-0 sm:visible sm:w-auto">Home</p>
+          <Home className="sm:invisible sm:w-0" />
+        </Link>
+      </li>
+      <li>
+        {userEmail ? (
+          <div className="flex items-center gap-4 font-medium text-foreground/60">
+            Hi, {userEmail}!
+            <form action={signOut}>
+              <button className={cn(
+                buttonVariants({ variant: 'ghost' }),
+                'px-2 md:px-4',
+                'hover:bg-transparent hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0',
+              )}>
+                Log Out
+              </button>
+            </form>
+          </div>
+        ) : (
+          <Link
+            href="/login"
+            className={cn(
+              buttonVariants({ variant: 'ghost' }),
+              'px-2 md:px-4',
+              'hover:bg-transparent hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0',
+              pathname === '/login' ? 'text-foreground' : 'text-foreground/60',
+            )}
+          >
+            Log In
+          </Link>
+        )}
+      </li>
+      <li>
+        <ThemeToggleButton />
+      </li>
+    </ul>
+  );
+}


### PR DESCRIPTION
This PR:
- Refactors the main navigation by:
  - Splitting the `MainNavigation` into the `MainNavigation` server component and the `MainNavigationMenu` client component;
  - Moving the supabase server client creation and the `getUser()` call from the `@/app/layout.tsx` to the `@/components/MainNavigation.tsx `.